### PR TITLE
Add links to Frameworks and Prototypes on Assets page

### DIFF
--- a/src/pages/assets.astro
+++ b/src/pages/assets.astro
@@ -43,14 +43,22 @@ const metadata = {
       {
         title: 'Frameworks',
         description:
-          'Proprietary and open frameworks we use to guide decision-making, strategy, and analysis. Coming soon.',
+          'Proprietary and open frameworks we use to guide decision-making, strategy, and analysis.',
         icon: 'tabler:sitemap',
+        callToAction: {
+          text: 'View frameworks',
+          href: 'https://frameworks.deerfieldgreen.com/',
+        },
       },
       {
         title: 'Prototypes',
         description:
-          'Experimental projects and proof-of-concept work from our incubator and research teams. Coming soon.',
+          'Experimental projects and proof-of-concept work from our incubator and research teams.',
         icon: 'tabler:flask',
+        callToAction: {
+          text: 'View prototypes',
+          href: 'https://prototypes.deerfieldgreen.com/',
+        },
       },
     ]}
   />


### PR DESCRIPTION
## Summary
- Add links to frameworks.deerfieldgreen.com and prototypes.deerfieldgreen.com on the Assets page
- Remove "Coming soon." from Frameworks and Prototypes descriptions

## Test plan
- [ ] Verify Assets page renders with new links
- [ ] Confirm links open correct subdomains

🤖 Generated with [Claude Code](https://claude.com/claude-code)