### PR TITLE
chore: add black pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.9.0
+    hooks:
+      - id: black


### PR DESCRIPTION
Adds Black auto-formatter as a pre-commit hook using [psf/black-pre-commit-mirror](https://github.com/psf/black-pre-commit-mirror) at rev 25.9.0. Black will automatically format Python files on every `git commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)