### PR TITLE
Fix CI: add --legacy-peer-deps for Astro 6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build Astro
         run: npm run build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,7 +18,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build Astro
         run: npm run build


### PR DESCRIPTION
## Summary
- Deploys have been failing since PR #22 (Astro 6 migration)
- `@astrolib/analytics@0.6.1` peer depends on astro ^5.0.0
- Add `--legacy-peer-deps` to `npm ci` in both deploy and preview workflows

## Test plan
- [ ] Verify deploy workflow succeeds after merge
- [ ] Verify site is live on Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)