### PR TITLE
Fix CI: upgrade Node.js 20 to 22 for Astro 6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Astro 6 requires Node.js >= 22.12.0, workflows were using Node 20
- Upgrade both deploy and preview workflows to Node 22

## Test plan
- [ ] Verify deploy succeeds and site goes live on Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)