### PR TITLE
Add .npmrc for CI peer deps fix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- The wrangler-action runs its own `npm install`, ignoring workflow-level flags
- Adding `.npmrc` with `legacy-peer-deps=true` ensures all npm installs skip strict peer checks
- Fixes Cloudflare Pages deploy failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)