### PR TITLE
Wire /contact/ form to Resend via Cloudflare Pages Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Thumbs.db
 
 # Cloudflare
 .wrangler/
+.dev.vars
 
 # Build / misc
 *.log

--- a/functions/contact.ts
+++ b/functions/contact.ts
@@ -1,0 +1,101 @@
+// Cloudflare Pages Function — handles POST /contact.
+//
+// Reads form data, rejects honeypot/invalid submissions, forwards the
+// message via Resend to contact@deerfieldgreen.com, and redirects the
+// user to a branded thank-you page.
+//
+// Runs on the Workers runtime at the edge. No npm deps — fetch, Response,
+// FormData are all built in.
+
+interface Env {
+  RESEND_API_KEY: string;
+}
+
+const FROM_ADDRESS = 'Deerfield Green Website <noreply@deerfieldgreen.com>';
+const TO_ADDRESS = 'contact@deerfieldgreen.com';
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function redirect(url: string): Response {
+  return new Response(null, { status: 303, headers: { Location: url } });
+}
+
+function isJa(lang: unknown): boolean {
+  return typeof lang === 'string' && lang === 'ja';
+}
+
+function errorUrl(lang: unknown): string {
+  return isJa(lang) ? '/ja/contact/?error=1#form' : '/contact/?error=1#form';
+}
+
+function thanksUrl(lang: unknown): string {
+  return isJa(lang) ? '/ja/contact/thanks/' : '/contact/thanks/';
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return redirect(errorUrl(null));
+  }
+
+  // Honeypot: real users leave this empty.
+  const hp = form.get('_hp');
+  if (typeof hp === 'string' && hp.trim() !== '') {
+    return new Response(null, { status: 204 });
+  }
+
+  const lang = form.get('_lang');
+  const name = (form.get('name') || '').toString().trim();
+  const email = (form.get('email') || '').toString().trim();
+  const message = (form.get('message') || '').toString().trim();
+  const disclaimer = form.get('disclaimer');
+
+  if (!name || !message || !email || !EMAIL_REGEX.test(email) || disclaimer !== 'on') {
+    return redirect(errorUrl(lang));
+  }
+
+  if (!env.RESEND_API_KEY) {
+    console.error('RESEND_API_KEY missing from Pages env');
+    return redirect(errorUrl(lang));
+  }
+
+  const submittedAt = new Date().toISOString();
+  const body = [
+    `Name: ${name}`,
+    `Email: ${email}`,
+    `Language: ${isJa(lang) ? 'ja' : 'en'}`,
+    `Submitted: ${submittedAt}`,
+    '',
+    'Message:',
+    message,
+  ].join('\n');
+
+  try {
+    const resp = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: FROM_ADDRESS,
+        to: [TO_ADDRESS],
+        reply_to: email,
+        subject: `[deerfieldgreen.com] New contact form submission from ${name}`,
+        text: body,
+      }),
+    });
+
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '<no body>');
+      console.error('Resend API failure', resp.status, detail);
+      return redirect(errorUrl(lang));
+    }
+  } catch (err) {
+    console.error('Resend fetch threw', err);
+    return redirect(errorUrl(lang));
+  }
+
+  return redirect(thanksUrl(lang));
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@astrojs/check": "^0.9.4",
         "@astrojs/mdx": "^5.0.3",
         "@astrojs/partytown": "^2.1.7",
+        "@cloudflare/workers-types": "^4.20260420.1",
         "@eslint/js": "^9.33.0",
         "@iconify-json/flat-color-icons": "^1.2.1",
         "@iconify-json/tabler": "^1.2.20",
@@ -636,6 +637,13 @@
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260420.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260420.1.tgz",
+      "integrity": "sha512-DHT9JnSn9cIiCSdL76OxW+Xvc1+ml1CWzWvgVwreoHQ+E604aeFxPPHp9X7nE+XRWm2NH4l0OgtxUI5T/nuI3g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/partytown": "^2.1.7",
+    "@cloudflare/workers-types": "^4.20260420.1",
     "@eslint/js": "^9.33.0",
     "@iconify-json/flat-color-icons": "^1.2.1",
     "@iconify-json/tabler": "^1.2.20",

--- a/src/components/ui/Form.astro
+++ b/src/components/ui/Form.astro
@@ -2,10 +2,31 @@
 import type { Form as Props } from '~/types';
 import Button from '~/components/ui/Button.astro';
 
-const { inputs, textarea, disclaimer, button = 'Contact us', description = '' } = Astro.props;
+const { inputs, textarea, disclaimer, button = 'Contact us', description = '', action, method } = Astro.props;
+
+// Language hint travels with the POST so the handler can redirect to the
+// correct locale's thank-you / error page.
+const lang = Astro.url.pathname.startsWith('/ja') ? 'ja' : 'en';
 ---
 
-<form>
+<form {...action ? { action } : {}} {...method ? { method } : action ? { method: 'POST' } : {}}>
+  {
+    action && (
+      <>
+        {/* Honeypot — real users leave this empty. */}
+        <input
+          type="text"
+          name="_hp"
+          tabindex="-1"
+          autocomplete="off"
+          aria-hidden="true"
+          class="hidden"
+          style="position:absolute;left:-10000px;top:auto;width:1px;height:1px;overflow:hidden;"
+        />
+        <input type="hidden" name="_lang" value={lang} />
+      </>
+    )
+  }
   {
     inputs &&
       inputs.map(

--- a/src/components/widgets/Contact.astro
+++ b/src/components/widgets/Contact.astro
@@ -13,6 +13,8 @@ const {
   disclaimer,
   button,
   description,
+  action,
+  method,
 
   id,
   isDark = false,
@@ -33,6 +35,8 @@ const {
           disclaimer={disclaimer}
           button={button}
           description={description}
+          action={action}
+          method={method}
         />
       </div>
     )

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,6 +10,8 @@ const metadata = {
   title: 'Contact Us',
   description: 'Get in touch with the Deerfield Green team in Tokyo and Atlanta',
 };
+
+const hasError = Astro.url.searchParams.has('error');
 ---
 
 <Layout metadata={metadata}>
@@ -27,10 +29,28 @@ const metadata = {
     <PaperGrain tone="light" opacity={0.03} />
     <div class="max-w-7xl mx-auto px-6 md:px-10 relative">
       <SeamDivider variant="default" tone="light" class="mb-16" />
+      {
+        hasError && (
+          <div
+            id="form"
+            role="alert"
+            class="max-w-xl mx-auto mb-8 border border-[var(--aw-color-primary)] bg-[var(--aw-color-bg-surface)] px-5 py-4"
+          >
+            <p class="font-mono text-[11px] tracking-[0.22em] uppercase text-[var(--aw-color-primary)] mb-1">
+              § Error
+            </p>
+            <p class="text-[var(--aw-color-text-default)] text-sm">
+              We couldn't send that. Please check your entries — including the acknowledgement — and try again.
+            </p>
+          </div>
+        )
+      }
       <ContactForm
         id="form"
         title="Leave a Message"
         subtitle="We'd love to hear from you. Fill out the form below and our team will respond promptly."
+        action="/contact"
+        method="POST"
         inputs={[
           { type: 'text', name: 'name', label: 'Name' },
           { type: 'email', name: 'email', label: 'Email' },

--- a/src/pages/contact/thanks.astro
+++ b/src/pages/contact/thanks.astro
@@ -1,0 +1,33 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroKintsugi from '~/components/widgets/v2/HeroKintsugi.astro';
+import CTASumi from '~/components/widgets/v2/CTASumi.astro';
+
+const metadata = {
+  title: 'Message Received',
+  description: 'Thanks for reaching out — we\'ll be in touch shortly.',
+  robots: { index: false, follow: false },
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero ******************* -->
+  <HeroKintsugi
+    eyebrow="§ 01 / THANK YOU"
+    titleEn="Message received."
+    titleJa="メッセージを受け取りました。"
+    subtitle="Thanks for reaching out. Our team typically responds within a few business days."
+    primaryLang="en"
+  />
+
+  <!-- CTA ******************* -->
+  <CTASumi
+    id="return"
+    eyebrow="§ 02 / HOME"
+    titleEn="Continue exploring."
+    titleJa="引き続きご覧ください。"
+    subtitle="Return to the homepage or read more about our work."
+    actions={[{ variant: 'primary', text: 'Return home →', href: '/' }]}
+    primaryLang="en"
+  />
+</Layout>

--- a/src/pages/ja/contact.astro
+++ b/src/pages/ja/contact.astro
@@ -10,6 +10,8 @@ const metadata = {
   title: '連絡先',
   description: 'お問い合わせ',
 };
+
+const hasError = Astro.url.searchParams.has('error');
 ---
 
 <Layout metadata={metadata}>
@@ -27,10 +29,28 @@ const metadata = {
     <PaperGrain tone="light" opacity={0.03} />
     <div class="max-w-7xl mx-auto px-6 md:px-10 relative">
       <SeamDivider variant="default" tone="light" class="mb-16" />
+      {
+        hasError && (
+          <div
+            id="form"
+            role="alert"
+            class="max-w-xl mx-auto mb-8 border border-[var(--aw-color-primary)] bg-[var(--aw-color-bg-surface)] px-5 py-4"
+          >
+            <p class="font-mono text-[11px] tracking-[0.22em] uppercase text-[var(--aw-color-primary)] mb-1">
+              § エラー
+            </p>
+            <p class="text-[var(--aw-color-text-default)] text-sm">
+              送信できませんでした。ご確認のチェックを含め、内容をご確認のうえ、もう一度お試しください。
+            </p>
+          </div>
+        )
+      }
       <ContactForm
         id="form"
         title="メッセージを残す"
         subtitle="アイデアをお持ちですか？このフォームを使ってメッセージをお送りください。"
+        action="/contact"
+        method="POST"
         inputs={[
           { type: 'text', name: 'name', label: 'お名前' },
           { type: 'email', name: 'email', label: 'メールアドレス' },

--- a/src/pages/ja/contact/thanks.astro
+++ b/src/pages/ja/contact/thanks.astro
@@ -1,0 +1,33 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import HeroKintsugi from '~/components/widgets/v2/HeroKintsugi.astro';
+import CTASumi from '~/components/widgets/v2/CTASumi.astro';
+
+const metadata = {
+  title: 'メッセージを受け取りました',
+  description: 'お問い合わせありがとうございます。数営業日以内にご返信いたします。',
+  robots: { index: false, follow: false },
+};
+---
+
+<Layout metadata={metadata}>
+  <!-- Hero ******************* -->
+  <HeroKintsugi
+    eyebrow="§ 01 / ありがとうございます"
+    titleEn="Message received."
+    titleJa="メッセージを受け取りました。"
+    subtitle="お問い合わせいただきありがとうございます。通常、数営業日以内にご返信いたします。"
+    primaryLang="ja"
+  />
+
+  <!-- CTA ******************* -->
+  <CTASumi
+    id="return"
+    eyebrow="§ 02 / ホーム"
+    titleEn="Continue exploring."
+    titleJa="引き続きご覧ください。"
+    subtitle="ホームページに戻るか、私たちの取り組みについてさらに詳しくご覧ください。"
+    actions={[{ variant: 'primary', text: 'ホームに戻る →', href: '/ja/' }]}
+    primaryLang="ja"
+  />
+</Layout>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -210,6 +210,8 @@ export interface Form {
   disclaimer?: Disclaimer;
   button?: string;
   description?: string;
+  action?: string;
+  method?: string;
 }
 
 // WIDGETS

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]
-    }
+    },
+    "types": ["@cloudflare/workers-types"]
   },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist/"]


### PR DESCRIPTION
## Summary
- Adds `functions/contact.ts` (Cloudflare Pages Function) to receive the form POST, validate it, and forward via Resend to `contact@deerfieldgreen.com`.
- Branded Kintsugi thank-you pages at `/contact/thanks/` and `/ja/contact/thanks/` (both `noindex`).
- Inline error banner on `/contact/` and `/ja/contact/` when `?error=1` is present (the Function redirects there on validation or send failure).
- Honeypot (`_hp`) + hidden `_lang` field added to the shared `Form.astro` for defense-in-depth against bots.
- Site stays static (`output: 'static'`); the Pages Function runs separately on the Workers runtime.

## Before this merges, prerequisites in Cloudflare / Resend
- [ ] Resend account created and `deerfieldgreen.com` verified (DKIM + SPF DNS records added in Cloudflare DNS)
- [ ] `RESEND_API_KEY` added to Cloudflare Pages env for both **Production** and **Preview**
- [ ] Key mirrored in Doppler `deerfieldgreen-www / prd` for parity
- [ ] A FROM address on the verified domain confirmed (the handler uses `noreply@deerfieldgreen.com`)

## Test plan
- [ ] Submit a valid message on the PR preview URL (`pr-N.deerfieldgreen-www.pages.dev/contact/`) → receive email at `contact@deerfieldgreen.com`, land on `/contact/thanks/`
- [ ] Submit without the disclaimer checkbox → redirect back to `/contact/?error=1#form` with inline error
- [ ] Submit from `/ja/contact/` → email shows `Language: ja`, redirect to `/ja/contact/thanks/`
- [ ] Inspect a delivered email's raw source for `DKIM=pass` and `SPF=pass`; confirm `Reply-To:` is the submitter's address
- [ ] Populate `_hp` honeypot via devtools → server returns 204, no email sent
- [ ] `npm run check:astro` + `npm run build` clean (85 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)